### PR TITLE
Update dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,9 +19,9 @@ import PackageDescription
 let package = Package(
     name: "TensorsFittingPerfectly",
     dependencies: [
-         .package(url: "https://github.com/tensorflow/swift", .branch("master")),
+         .package(url: "https://github.com/tensorflow/swift", .branch("main")),
          // FIXME: We need this for command-line argument parsing only.
-         .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.1.0"),
+         .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.1.12"),
     ],
     targets: [
         .target(
@@ -29,7 +29,7 @@ let package = Package(
             dependencies: [
               "LibTFP",
               "SIL",
-              "SPMUtility"]),
+              "SwiftToolsSupport"]),
         .target(
             name: "LibTFP",
             dependencies: [

--- a/Sources/LibTFP/Solvers/Z3/Z3.swift
+++ b/Sources/LibTFP/Solvers/Z3/Z3.swift
@@ -148,7 +148,7 @@ class Z3Model: CustomStringConvertible {
       return nil
     }
     var result: Int64 = 0
-    guard Z3_get_numeral_int64(ctx.ctx, interpretation, &result) else {
+    guard Z3_get_numeral_int64(ctx.ctx, interpretation, &result) != 0 else {
       fatalError("Interpretation does not fit into an int64")
     }
     return Int(result)

--- a/Sources/doesitfit/main.swift
+++ b/Sources/doesitfit/main.swift
@@ -14,7 +14,7 @@
 
 @testable import LibTFP
 import SIL
-import SPMUtility
+import TSCUtility
 
 // TODO: Would it be safe to strip all the assumptions in the core?
 //       If the cores are guaranteed to be _minimal_ then I think so,


### PR DESCRIPTION
swift-package-manager no longer has `SPMUtility`, it was moved to swift-tools-support-core and named `TSCUtility`. 

tensorflow/swift no longer has a `master` branch, it was renamed to `main`.